### PR TITLE
Enhanced field template

### DIFF
--- a/materialize_forms/templates/materialize/field_visible.html
+++ b/materialize_forms/templates/materialize/field_visible.html
@@ -12,7 +12,6 @@
     {% include "materialize/field_help.html" with display="block" %}
 {% elif input_type == "text" or input_type == "textarea" or input_type == "url" or input_type == "email" %}
     <div class="input-field col {{ col }}">
-        text field
         {{ field }}
         <label for="{{ field.auto_id }}"
                data-error="{% if field.errors %}{{ field.errors.0.error }}{% endif %}">

--- a/materialize_forms/templates/materialize/field_visible.html
+++ b/materialize_forms/templates/materialize/field_visible.html
@@ -13,7 +13,12 @@
 {% elif input_type == "text" or input_type == "textarea" or input_type == "url" or input_type == "email" %}
     <div class="input-field col {{ col }}">
         {{ field }}
-        <label for="{{ field.auto_id }}">{{ field.label }}</label>
+        <label for="{{ field.auto_id }}">
+            {{ field.label }}
+            {% if field.required %}
+                <span style="color: red; margin-left: 3px;">*</span>
+            {% endif %}
+        </label>
         {% include "materialize/field_help.html" %}
         {% include "materialize/field_errors.html" %}
     </div>

--- a/materialize_forms/templates/materialize/field_visible.html
+++ b/materialize_forms/templates/materialize/field_visible.html
@@ -12,8 +12,8 @@
     {% include "materialize/field_help.html" with display="block" %}
 {% elif input_type == "text" or input_type == "textarea" or input_type == "url" or input_type == "email" %}
     <div class="input-field col {{ col }}">
-        <label for="{{ field.auto_id }}">{{ field.label }}</label>
         {{ field }}
+        <label for="{{ field.auto_id }}">{{ field.label }}</label>
         {% include "materialize/field_help.html" %}
         {% include "materialize/field_errors.html" %}
     </div>
@@ -38,6 +38,14 @@
             </div>
             {% include "materialize/field_errors.html" %}
         </div>
+    </div>
+{% elif input_type == "date" %}
+    <div class="col {{ col }}">
+        <label for="{{ field.auto_id }}"
+               data-error="{% if field.errors %}{{ field.errors.0.error }}{% endif %}">
+            {{ field.label }}
+        </label>
+        {{ field }}
     </div>
 {% else %}
     {# treat all other input_types as a text input field #}

--- a/materialize_forms/templates/materialize/field_visible.html
+++ b/materialize_forms/templates/materialize/field_visible.html
@@ -12,15 +12,15 @@
     {% include "materialize/field_help.html" with display="block" %}
 {% elif input_type == "text" or input_type == "textarea" or input_type == "url" or input_type == "email" %}
     <div class="input-field col {{ col }}">
+        text field
         {{ field }}
-        <label for="{{ field.auto_id }}">
+        <label for="{{ field.auto_id }}"
+               data-error="{% if field.errors %}{{ field.errors.0.error }}{% endif %}">
             {{ field.label }}
             {% if field.field.required %}
-                <span style="color: red; margin-left: 3px;">*</span>
+                <span style="color: red;">*</span>
             {% endif %}
         </label>
-        {% include "materialize/field_help.html" %}
-        {% include "materialize/field_errors.html" %}
     </div>
 {% elif input_type == "select" %}
     <div class="input-field col {{ col }}">
@@ -46,6 +46,7 @@
     </div>
 {% elif input_type == "date" or input_type == "time" %}
     <div class="col {{ col }}">
+        {{ field }}
         <label for="{{ field.auto_id }}"
                data-error="{% if field.errors %}{{ field.errors.0.error }}{% endif %}">
             {{ field.label }}

--- a/materialize_forms/templates/materialize/field_visible.html
+++ b/materialize_forms/templates/materialize/field_visible.html
@@ -45,7 +45,6 @@
     </div>
 {% elif input_type == "date" or input_type == "time" %}
     <div class="col {{ col }}">
-        {{ field }}
         <label for="{{ field.auto_id }}"
                data-error="{% if field.errors %}{{ field.errors.0.error }}{% endif %}">
             {{ field.label }}

--- a/materialize_forms/templates/materialize/field_visible.html
+++ b/materialize_forms/templates/materialize/field_visible.html
@@ -39,7 +39,7 @@
             {% include "materialize/field_errors.html" %}
         </div>
     </div>
-{% elif input_type == "date" %}
+{% elif input_type == "date" or input_type == "time" %}
     <div class="col {{ col }}">
         <label for="{{ field.auto_id }}"
                data-error="{% if field.errors %}{{ field.errors.0.error }}{% endif %}">

--- a/materialize_forms/templates/materialize/field_visible.html
+++ b/materialize_forms/templates/materialize/field_visible.html
@@ -15,7 +15,7 @@
         {{ field }}
         <label for="{{ field.auto_id }}">
             {{ field.label }}
-            {% if field.required %}
+            {% if field.field.required %}
                 <span style="color: red; margin-left: 3px;">*</span>
             {% endif %}
         </label>

--- a/materialize_forms/templates/materialize/field_visible.html
+++ b/materialize_forms/templates/materialize/field_visible.html
@@ -30,15 +30,14 @@
 {% elif input_type == "select" %}
     <div class="input-field col {{ col }}">
         {{ field }}
-        <label for="{{ field.auto_id }}">
+        <label for="{{ field.auto_id }}"
+               data-error="{% if field.errors %}{{ field.errors.0.error }}{% endif %}">
             {{ field.label }}
 
             {% if field.field.required %}
                 <span style="color: red;">*</span>
             {% endif %}
         </label>
-        {% include "materialize/field_help.html" %}
-        {% include "materialize/field_errors.html" %}
     </div>
 {% elif input_type == "file" %}
     <div class="col {{ col }}">

--- a/materialize_forms/templates/materialize/field_visible.html
+++ b/materialize_forms/templates/materialize/field_visible.html
@@ -1,7 +1,13 @@
 {% if input_type == "checkbox" %}
     <div style="padding:10px" {% if col %}class="col {{ col }}"{% endif %}>
         {{ field }}
-        <label for="{{ field.auto_id }}">{{ field.label }}</label>
+        <label for="{{ field.auto_id }}">
+            {{ field.label }}
+
+            {% if field.field.required %}
+                <span style="color: red;">*</span>
+            {% endif %}
+        </label>
         {% include "materialize/field_help.html" %}
     </div>
 {% elif input_type == "multicheckbox" %}
@@ -24,13 +30,25 @@
 {% elif input_type == "select" %}
     <div class="input-field col {{ col }}">
         {{ field }}
-        <label for="{{ field.auto_id }}">{{ field.label }}</label>
+        <label for="{{ field.auto_id }}">
+            {{ field.label }}
+
+            {% if field.field.required %}
+                <span style="color: red;">*</span>
+            {% endif %}
+        </label>
         {% include "materialize/field_help.html" %}
         {% include "materialize/field_errors.html" %}
     </div>
 {% elif input_type == "file" %}
     <div class="col {{ col }}">
-        <label for="{{ field.auto_id }}">{{ field.label }}</label>
+        <label for="{{ field.auto_id }}">
+            {{ field.label }}
+
+            {% if field.field.required %}
+                <span style="color: red;">*</span>
+            {% endif %}
+        </label>
         <div class="file-field input-field">
             <div class="btn">
                 <span>File</span>
@@ -48,13 +66,22 @@
         <label for="{{ field.auto_id }}"
                data-error="{% if field.errors %}{{ field.errors.0.error }}{% endif %}">
             {{ field.label }}
+            {% if field.field.required %}
+                <span style="color: red;">*</span>
+            {% endif %}
         </label>
         {{ field }}
     </div>
 {% else %}
     {# treat all other input_types as a text input field #}
     <div class="col {{ col }}" style="padding:10px">
-        <label for="{{ field.auto_id }}" style="margin-bottom:10px;">{{ field.label }}</label>
+        <label for="{{ field.auto_id }}" style="margin-bottom:10px;">
+            {{ field.label }}
+
+            {% if field.field.required %}
+                <span style="color: red;">*</span>
+            {% endif %}
+        </label>
         <br/>
         <br/>
         {{ field }}

--- a/materialize_forms/templatetags/materialize.py
+++ b/materialize_forms/templatetags/materialize.py
@@ -30,9 +30,8 @@ def as_material(field, col='s6'):
         clazz = {'class': 'validate'}
     widget.attrs.update(clazz)
 
-    if field.field.required:
-        if field.field.label:
-            field.field.label += '<span style="color: red; margin-left: 3px;">*</span>'
+    if field.field.required and field.label:
+            field.label += '<span style="color: red; margin-left: 3px;">*</span>'
 
     if isinstance(field.field, CharField) and field.help_text:
         placeholder_attr = {'placeholder': field.help_text}

--- a/materialize_forms/templatetags/materialize.py
+++ b/materialize_forms/templatetags/materialize.py
@@ -33,6 +33,7 @@ def as_material(field, col='s6'):
     if isinstance(field.field, DateField):
         input_type = u'date'
         add_css_class_widget(widget, 'datepicker')
+        widget.attrs['type'] = 'date'
     else:
         try:
             input_type = widget.input_type

--- a/materialize_forms/templatetags/materialize.py
+++ b/materialize_forms/templatetags/materialize.py
@@ -30,9 +30,6 @@ def as_material(field, col='s6'):
         clazz = {'class': 'validate'}
     widget.attrs.update(clazz)
 
-    if field.field.required and field.label:
-            field.label += '<span style="color: red; margin-left: 3px;">*</span>'
-
     if isinstance(field.field, CharField) and field.help_text:
         placeholder_attr = {'placeholder': field.help_text}
         widget.attrs.update(placeholder_attr)

--- a/materialize_forms/templatetags/materialize.py
+++ b/materialize_forms/templatetags/materialize.py
@@ -33,7 +33,7 @@ def as_material(field, col='s6'):
     if isinstance(field.field, DateField):
         input_type = u'date'
         add_css_class_widget(widget, 'datepicker')
-        widget_type = {'test': 'data'}
+        widget_type = {'input_type': 'date'}
         widget.attrs.update(widget_type)
     else:
         try:

--- a/materialize_forms/templatetags/materialize.py
+++ b/materialize_forms/templatetags/materialize.py
@@ -33,23 +33,23 @@ def as_material(field, col='s6'):
     if isinstance(field.field, DateField):
         input_type = u'date'
         add_css_class_widget(widget, 'datepicker')
-
-    try:
-        input_type = widget.input_type
-    except AttributeError:
-        if isinstance(widget, widgets.Textarea):
-            input_type = u'textarea'
-            add_css_class_widget(widget, 'materialize-textarea')
-        elif isinstance(widget, widgets.CheckboxInput):
-            input_type = u'checkbox'
-        elif isinstance(widget, widgets.CheckboxSelectMultiple):
-            input_type = u'multicheckbox'
-        elif isinstance(widget, widgets.RadioSelect):
-            input_type = u'radio'
-        elif isinstance(widget, widgets.Select):
-            input_type = u'select'
-        else:
-            input_type = u'default'
+    else:
+        try:
+            input_type = widget.input_type
+        except AttributeError:
+            if isinstance(widget, widgets.Textarea):
+                input_type = u'textarea'
+                add_css_class_widget(widget, 'materialize-textarea')
+            elif isinstance(widget, widgets.CheckboxInput):
+                input_type = u'checkbox'
+            elif isinstance(widget, widgets.CheckboxSelectMultiple):
+                input_type = u'multicheckbox'
+            elif isinstance(widget, widgets.RadioSelect):
+                input_type = u'radio'
+            elif isinstance(widget, widgets.Select):
+                input_type = u'select'
+            else:
+                input_type = u'default'
 
     return get_template("materialize/field.html").render({
         'field': field,

--- a/materialize_forms/templatetags/materialize.py
+++ b/materialize_forms/templatetags/materialize.py
@@ -31,7 +31,8 @@ def as_material(field, col='s6'):
     widget.attrs.update(clazz)
 
     if field.field.required:
-        field.field.label += '<span style="color: red; margin-left: 3px;">*</span>'
+        if field.field.label:
+            field.field.label += '<span style="color: red; margin-left: 3px;">*</span>'
 
     if isinstance(field.field, CharField) and field.help_text:
         placeholder_attr = {'placeholder': field.help_text}

--- a/materialize_forms/templatetags/materialize.py
+++ b/materialize_forms/templatetags/materialize.py
@@ -1,6 +1,6 @@
 from django import template
 from django.forms import widgets
-from django.forms.fields import DateField, TimeField
+from django.forms.fields import DateField, TimeField, CharField
 from django.template import Context
 from django.template.loader import get_template
 from django.utils.html import escape
@@ -29,6 +29,10 @@ def as_material(field, col='s6'):
     except KeyError:
         clazz = {'class': 'validate'}
     widget.attrs.update(clazz)
+
+    if isinstance(field.field, CharField) and field.help_text:
+        placeholder_attr = {'placeholder': field.help_text}
+        widget.attrs.update(placeholder_attr)
 
     if isinstance(field.field, DateField):
         input_type = u'date'

--- a/materialize_forms/templatetags/materialize.py
+++ b/materialize_forms/templatetags/materialize.py
@@ -30,8 +30,6 @@ def as_material(field, col='s6'):
         clazz = {'class': 'validate'}
     widget.attrs.update(clazz)
 
-    if isinstance(field.field, DateField):
-        add_css_class_widget(widget, 'datepicker')
 
     try:
         input_type = widget.input_type
@@ -39,6 +37,9 @@ def as_material(field, col='s6'):
         if isinstance(widget, widgets.Textarea):
             input_type = u'textarea'
             add_css_class_widget(widget, 'materialize-textarea')
+        elif isinstance(field.field, DateField):
+            input_type = u'date'
+            add_css_class_widget(widget, 'datepicker')
         elif isinstance(widget, widgets.CheckboxInput):
             input_type = u'checkbox'
         elif isinstance(widget, widgets.CheckboxSelectMultiple):

--- a/materialize_forms/templatetags/materialize.py
+++ b/materialize_forms/templatetags/materialize.py
@@ -30,6 +30,9 @@ def as_material(field, col='s6'):
         clazz = {'class': 'validate'}
     widget.attrs.update(clazz)
 
+    if field.field.required:
+        field.field.label += '<span style="color: red; margin-left: 3px;">*</span>'
+
     if isinstance(field.field, CharField) and field.help_text:
         placeholder_attr = {'placeholder': field.help_text}
         widget.attrs.update(placeholder_attr)

--- a/materialize_forms/templatetags/materialize.py
+++ b/materialize_forms/templatetags/materialize.py
@@ -33,8 +33,6 @@ def as_material(field, col='s6'):
     if isinstance(field.field, DateField):
         input_type = u'date'
         add_css_class_widget(widget, 'datepicker')
-        # widget_type = {'input_type': 'date'}
-        # widget.attrs.update(widget_type)
         widget.input_type = 'date'
     else:
         try:

--- a/materialize_forms/templatetags/materialize.py
+++ b/materialize_forms/templatetags/materialize.py
@@ -1,6 +1,6 @@
 from django import template
 from django.forms import widgets
-from django.forms.fields import DateField
+from django.forms.fields import DateField, TimeField
 from django.template import Context
 from django.template.loader import get_template
 from django.utils.html import escape

--- a/materialize_forms/templatetags/materialize.py
+++ b/materialize_forms/templatetags/materialize.py
@@ -33,7 +33,8 @@ def as_material(field, col='s6'):
     if isinstance(field.field, DateField):
         input_type = u'date'
         add_css_class_widget(widget, 'datepicker')
-        widget.attrs['type'] = 'date'
+        widget_type = {'type': 'date'}
+        widget.attrs.update(widget_type)
     else:
         try:
             input_type = widget.input_type

--- a/materialize_forms/templatetags/materialize.py
+++ b/materialize_forms/templatetags/materialize.py
@@ -33,7 +33,7 @@ def as_material(field, col='s6'):
     if isinstance(field.field, DateField):
         input_type = u'date'
         add_css_class_widget(widget, 'datepicker')
-        widget_type = {'type': 'date'}
+        widget_type = {'test': 'data'}
         widget.attrs.update(widget_type)
     else:
         try:

--- a/materialize_forms/templatetags/materialize.py
+++ b/materialize_forms/templatetags/materialize.py
@@ -33,8 +33,9 @@ def as_material(field, col='s6'):
     if isinstance(field.field, DateField):
         input_type = u'date'
         add_css_class_widget(widget, 'datepicker')
-        widget_type = {'input_type': 'date'}
-        widget.attrs.update(widget_type)
+        # widget_type = {'input_type': 'date'}
+        # widget.attrs.update(widget_type)
+        widget.input_type = 'date'
     else:
         try:
             input_type = widget.input_type

--- a/materialize_forms/templatetags/materialize.py
+++ b/materialize_forms/templatetags/materialize.py
@@ -34,6 +34,10 @@ def as_material(field, col='s6'):
         input_type = u'date'
         add_css_class_widget(widget, 'datepicker')
         widget.input_type = 'date'
+    elif isinstance(field.field, TimeField):
+        input_type = u'time'
+        add_css_class_widget(widget, 'timepicker')
+        widget.input_type = 'time'
     else:
         try:
             input_type = widget.input_type

--- a/materialize_forms/templatetags/materialize.py
+++ b/materialize_forms/templatetags/materialize.py
@@ -30,6 +30,9 @@ def as_material(field, col='s6'):
         clazz = {'class': 'validate'}
     widget.attrs.update(clazz)
 
+    if isinstance(field.field, DateField):
+        input_type = u'date'
+        add_css_class_widget(widget, 'datepicker')
 
     try:
         input_type = widget.input_type
@@ -37,9 +40,6 @@ def as_material(field, col='s6'):
         if isinstance(widget, widgets.Textarea):
             input_type = u'textarea'
             add_css_class_widget(widget, 'materialize-textarea')
-        elif isinstance(field.field, DateField):
-            input_type = u'date'
-            add_css_class_widget(widget, 'datepicker')
         elif isinstance(widget, widgets.CheckboxInput):
             input_type = u'checkbox'
         elif isinstance(widget, widgets.CheckboxSelectMultiple):


### PR DESCRIPTION
Added a few features, including showing field errors in the `data-error` attribute that Materialize provides, as well show a red asterisk for required fields.

Removed help_text template includes for most fields at this time, because most of them can be added as placeholders.